### PR TITLE
Don't kill cyclists with helmets from the ejection itself.

### DIFF
--- a/resources/np-oVehicleMod/client.lua
+++ b/resources/np-oVehicleMod/client.lua
@@ -164,7 +164,7 @@ function ejectionLUL()
         -- Players on bicycles wearing helmets shouldn't die from the ejection itself. Instead, set HP to 1.
         -- Player will only die if further native damage occurs post ejection, more than the armour can protect.
         local damageAmount = GetEntityHealth(playerPed) - 1
-        if damageAmount < ejectspeed then
+        if damageAmount > ejectspeed then
             damageAmount = ejectspeed
         end
         SetEntityHealth(playerPed, GetEntityHealth(playerPed) - damageAmount)

--- a/resources/np-oVehicleMod/client.lua
+++ b/resources/np-oVehicleMod/client.lua
@@ -160,6 +160,16 @@ function ejectionLUL()
     SetPedToRagdoll(playerPed, 5511, 5511, 0, 0, 0, 0)
     SetEntityVelocity(playerPed, veloc.x*4,veloc.y*4,veloc.z*4)
     local ejectspeed = math.ceil(GetEntitySpeed(playerPed) * 8)
+    if IsPedWearingHelmet(playerPed) and IsThisModelABicycle(GetEntityModel(veh)) then
+        -- Players on bicycles wearing helmets shouldn't die from the ejection itself. Instead, set HP to 1.
+        -- Player will only die if further native damage occurs post ejection, more than the armour can protect.
+        local damageAmount = GetEntityHealth(playerPed) - 1
+        if damageAmount < ejectspeed then
+            damageAmount = ejectspeed
+        end
+        SetEntityHealth(playerPed, GetEntityHealth(playerPed) - damageAmount)
+        return
+    end
     SetEntityHealth(playerPed, (GetEntityHealth(playerPed) - ejectspeed) )
    -- TriggerEvent("randomBoneDamage")
 end


### PR DESCRIPTION
I've noticed a few things:
- Players can get killed from the `ejectionLUL()` logic itself as opposed to incurring partial damage and letting them die off due subsequent falling/impacts from the 4x speed applied to them. I have noticed this happens very often to the character Bogg during his stunts.
- **Cyclists currently have no benefit for wearing helmets.**
- `ApplyDamageToPed()` is not used anywhere on NoPixel and all custom damage is applied directly to health, ignoring armour.

In the interest of helping out cyclists with a minimal change and preserving existing behavior as much as possible, this pull request prevents ejection deaths if the cyclist is wearing a helmet and has more than 1 HP left. Instead, their health drops to 1 during ejection and they can very easily die from subsequent impacts or native fall damage if they're low on armour. Otherwise, note that cyclists with helmets incur the same amount of ejection damage as before.
